### PR TITLE
feat: Added M1 Max Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ to [raw_results.txt](raw_results.txt).
     <tbody>
         <tr>
             <td>Training a transformer <br> language model</td>
-            <td> OOM Error </td>
+            <td> 1106.75 </td>
             <td> 752.25 </td>
         </tr>
         <tr>
@@ -95,7 +95,7 @@ to [raw_results.txt](raw_results.txt).
         </tr>
         <tr>
             <td>Whisper inference</td>
-            <td> 21.43 </td>
+            <td> 21.28 </td>
             <td> 6.95 </td>
         </tr>
         <tr>

--- a/README.md
+++ b/README.md
@@ -72,6 +72,48 @@ to [raw_results.txt](raw_results.txt).
 <table>
 <thead>
 <tr>
+<th colspan="4">M1 Max (10 CPU core, 32 GPU core, 64 GB RAM) </th>
+</tr>
+</thead>
+    <thead>
+        <tr>
+            <th>Benchmark</th>
+            <th>PyTorch time (s)</th>
+            <th>MLX time (s)</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Training a transformer <br> language model</td>
+            <td> OOM Error </td>
+            <td> 752.25 </td>
+        </tr>
+        <tr>
+            <td>Training BERT</td>
+            <td> 793.67 </td>
+            <td> 499.34 </td>
+        </tr>
+        <tr>
+            <td>Whisper inference</td>
+            <td> 21.43 </td>
+            <td> 6.95 </td>
+        </tr>
+        <tr>
+            <td>TinyLLama inference</td>
+            <td> 50.98 </td>
+            <td> 20.61 </td>
+        </tr>
+        <tr>
+            <td>CPU/GPU switch</td>
+            <td> 251.71 </td>
+            <td> 214.57 </td>
+        </tr>
+    </tbody>
+</table>
+
+<table>
+<thead>
+<tr>
 <th colspan="4">M3 Max (16 CPU core, 40 GPU core, 48 GB RAM) </th>
 </tr>
 </thead>

--- a/raw_results.txt
+++ b/raw_results.txt
@@ -58,17 +58,18 @@ Framework: mlx
 => Values from three executions
 
 Framework: pytorch
-	Average: 
+	Average: - 
+	Error: RuntimeError: MPS backend out of memory (MPS allocated: 78.01 GB, other allocations: 2.38 GB, max allowed: 81.60 GB). Tried to allocate 2.00 GB on private pool. Use PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 to disable upper limit for memory allocations (may cause system failure)
 
 Framework: mlx
-	Average: 
+	Average: 752.2592077255249s - Median: 752.2592812234227s
 
 
 ---- Training BERT ----
 => Values from three executions
 
 Framework: pytorch
-	Average: 1136.4159963925679s - Median: 793.610111951828s
+	Average: 793.6759963925679s - Median: 793.610111951828s
 
 Framework: mlx
 	Average: 499.343544960022s - Median: 498.0613958835602s

--- a/raw_results.txt
+++ b/raw_results.txt
@@ -51,15 +51,12 @@ Framework: mlx
 ==================================================================
 
 ============================= M1 Max =============================
-====================== 64GB Unified Memory =======================
-==================== 10 CPU and 32 GPU Cores =====================
 
 ---- Training a transformers language model ----
 => Values from three executions
 
 Framework: pytorch
-	Average: - 
-	Error: RuntimeError: MPS backend out of memory (MPS allocated: 78.01 GB, other allocations: 2.38 GB, max allowed: 81.60 GB). Tried to allocate 2.00 GB on private pool. Use PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 to disable upper limit for memory allocations (may cause system failure)
+	Average: 1106.7549295464829s - Median: 1101.3749282211793s
 
 Framework: mlx
 	Average: 752.2592077255249s - Median: 752.2592812234227s
@@ -79,8 +76,7 @@ Framework: mlx
 => Values from ten executions
 
 Framework: pytorch 
-(Had to "export PYTORCH_ENABLE_MPS_FALLBACK=1" due to an "op not implemented on MPS" error)
-	Average: 21.43549997806549s - Median: 21.204530119895935s
+	Average: 21.27653947197935s - Median: 21.204530119895964s
 
 Framework: mlx
 	Average: 6.946336317062378s - Median: 6.937196493148804s

--- a/raw_results.txt
+++ b/raw_results.txt
@@ -81,7 +81,6 @@ Framework: pytorch
 Framework: mlx
 	Average: 6.946336317062378s - Median: 6.937196493148804s
 
-
 ---- TinyLLama inference ----
 => Values from ten executions
 
@@ -101,7 +100,6 @@ Framework: pytorch
 Framework: mlx
 	Average: Framework: mlx
 	Average: 214.5735635280609s - Median: 214.57463908195496s
-
 ==================================================================
 
 ============================= M3 Max =============================

--- a/raw_results.txt
+++ b/raw_results.txt
@@ -68,10 +68,10 @@ Framework: mlx
 => Values from three executions
 
 Framework: pytorch
-	Average: 
+	Average: 1136.4159963925679s - Median: 793.610111951828s
 
 Framework: mlx
-	Average: 
+	Average: 499.343544960022s - Median: 498.0613958835602s
 
 
 ---- Whisper inference ----

--- a/raw_results.txt
+++ b/raw_results.txt
@@ -50,6 +50,62 @@ Framework: mlx
 
 ==================================================================
 
+============================= M1 Max =============================
+====================== 64GB Unified Memory =======================
+==================== 10 CPU and 32 GPU Cores =====================
+
+---- Training a transformers language model ----
+=> Values from three executions
+
+Framework: pytorch
+	Average: 
+
+Framework: mlx
+	Average: 
+
+
+---- Training BERT ----
+=> Values from three executions
+
+Framework: pytorch
+	Average: 
+
+Framework: mlx
+	Average: 
+
+
+---- Whisper inference ----
+=> Values from ten executions
+
+Framework: pytorch 
+(Had to "export PYTORCH_ENABLE_MPS_FALLBACK=1" due to an "op not implemented on MPS" error)
+	Average: 21.43549997806549s - Median: 21.204530119895935s
+
+Framework: mlx
+	Average: 6.946336317062378s - Median: 6.937196493148804s
+
+
+---- TinyLLama inference ----
+=> Values from ten executions
+
+Framework: pytorch
+	Average: 50.98743650913239s - Median: 47.73779845237732s
+
+Framework: mlx
+	Average: 20.61291913986206s - Median: 20.613165140151978s
+
+
+---- CPU/GPU switch ----
+=> Values from ten executions
+
+Framework: pytorch
+	Average: 251.71098244190216s - Median: 252.021404504776s
+
+Framework: mlx
+	Average: Framework: mlx
+	Average: 214.5735635280609s - Median: 214.57463908195496s
+
+==================================================================
 
 ============================= M3 Max =============================
 

--- a/raw_results.txt
+++ b/raw_results.txt
@@ -30,6 +30,7 @@ Framework: pytorch
 Framework: mlx
 	Average: 8.509361457824706s - Median: 8.509169936180115s
 
+
 ---- TinyLLama inference ----
 => Values from ten executions
 
@@ -38,6 +39,7 @@ Framework: pytorch
 
 Framework: mlx
 	Average: 33.38054447174072s - Median: 33.322925329208374s
+
 
 ---- CPU/GPU switch ----
 => Values from ten executions
@@ -81,6 +83,7 @@ Framework: pytorch
 Framework: mlx
 	Average: 6.946336317062378s - Median: 6.937196493148804s
 
+
 ---- TinyLLama inference ----
 => Values from ten executions
 
@@ -98,8 +101,8 @@ Framework: pytorch
 	Average: 251.71098244190216s - Median: 252.021404504776s
 
 Framework: mlx
-	Average: Framework: mlx
 	Average: 214.5735635280609s - Median: 214.57463908195496s
+
 ==================================================================
 
 ============================= M3 Max =============================
@@ -133,6 +136,7 @@ Framework: pytorch
 Framework: mlx
 	Average: 4.8507798433303835s - Median: 4.839159846305847s
 
+
 ---- TinyLLama inference ----
 => Values from ten executions
 
@@ -141,6 +145,7 @@ Framework: pytorch
 
 Framework: mlx
 	Average: 15.41469841003418s - Median: 15.389396786689758s
+
 
 ---- CPU/GPU switch ----
 => Values from ten executions


### PR DESCRIPTION
Added results for M1 Max 64GB. Some notes:
1. Received OOM Error while training BasicLM with pytorch:
```
RuntimeError: MPS backend out of memory (MPS allocated: 78.01 GB, other allocations: 2.38 GB, max allowed: 81.60 GB). Tried to allocate 2.00 GB on private pool. Use PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 to disable upper limit for memory allocations (may cause system failure)
```
2. Had to "export PYTORCH_ENABLE_MPS_FALLBACK=1" due to an "op not implemented on MPS" error while doing whisper inference